### PR TITLE
Correction of Apple TV Commands

### DIFF
--- a/hki-base/addons/remote-control.yaml
+++ b/hki-base/addons/remote-control.yaml
@@ -15,4 +15,7 @@
   command_back: menu
   command_down: down
   command_home: top_menu
+  command_power: |
+    - home_hold
+    - select
   {% endif %}

--- a/hki-base/templates/other/remote-control.yaml
+++ b/hki-base/templates/other/remote-control.yaml
@@ -72,8 +72,11 @@ cards:
         action: call-service
         service: {{ service|default('androidtv.adb_command') }}
         service_data:
+        {% if ((config.type is defined) and (config.type == 'atv')) %}
+          delay_secs: 1
+        {% endif %}
           entity_id: {{ entity_media_player_remote }}
-          command: "{{ command_left|default("POWER") }}"
+          command: "{{ command_power|default("POWER") }}"
   - !include
     - '../button/hki-button.yaml'
     - template: hki-remote
@@ -86,7 +89,7 @@ cards:
         service: {{ service|default('androidtv.adb_command') }}
         service_data:
           entity_id: {{ entity_media_player_remote }}
-          command: "{{ command_left|default("UP") }}"
+          command: "{{ command_up|default("UP") }}"
   - !include
     - '../button/hki-button.yaml'
     - template: hki-remote
@@ -99,7 +102,7 @@ cards:
         service: {{ service|default('androidtv.adb_command') }}
         service_data:
           entity_id: {{ entity_media_player_remote }}
-          command: "{{ command_left|default("MENU") }}"
+          command: "{{ command_menu|default("MENU") }}"
   - !include
     - '../button/hki-button.yaml'
     - name: Netflix
@@ -137,7 +140,7 @@ cards:
         service: {{ service|default('androidtv.adb_command') }}
         service_data:
           entity_id: {{ entity_media_player_remote }}
-          command: "{{ command_left|default("CENTER") }}"
+          command: "{{ command_center|default("CENTER") }}"
   - !include
     - '../button/hki-button.yaml'
     - template: hki-remote
@@ -150,7 +153,7 @@ cards:
         service: {{ service|default('androidtv.adb_command') }}
         service_data:
           entity_id: {{ entity_media_player_remote }}
-          command: "{{ command_left|default("RIGHT") }}"
+          command: "{{ command_right|default("RIGHT") }}"
   - !include
     - '../button/hki-button.yaml'
     - name: Spotify
@@ -175,7 +178,7 @@ cards:
         service: {{ service|default('androidtv.adb_command') }}
         service_data:
           entity_id: {{ entity_media_player_remote }}
-          command: "{{ command_left|default("BACK") }}"
+          command: "{{ command_back|default("BACK") }}"
   - !include
     - '../button/hki-button.yaml'
     - template: hki-remote
@@ -188,7 +191,7 @@ cards:
         service: {{ service|default('androidtv.adb_command') }}
         service_data:
           entity_id: {{ entity_media_player_remote }}
-          command: "{{ command_left|default("DOWN") }}"
+          command: "{{ command_down|default("DOWN") }}"
   - !include
     - '../button/hki-button.yaml'
     - template: hki-remote
@@ -201,4 +204,4 @@ cards:
         service: {{ service|default('androidtv.adb_command') }}
         service_data:
           entity_id: {{ entity_media_player_remote }}
-          command: "{{ command_left|default("HOME") }}"
+          command: "{{ command_home|default("HOME") }}"


### PR DESCRIPTION
1. properly reference atv commands
2. Add atv command for power/sleep control

*All commands referencing atv config variable were previously using the command_left command*

*Also noticed no accomodation for power/sleep control of the Apple TV Added sleep command per [official example](https://www.home-assistant.io/integrations/apple_tv/#examples)*

***I haven't had the opportunity to test yet***